### PR TITLE
don't push user_shares to chain_slice when merged

### DIFF
--- a/powerpool/reporters/redis_reporter.py
+++ b/powerpool/reporters/redis_reporter.py
@@ -101,10 +101,11 @@ class RedisReporter(QueueStatReporter):
     def _queue_log_share(self, address, shares, algo, currency, merged=False):
         block_key = 'current_block_{}_{}'.format(currency, algo)
         chain_key = 'chain_{}_shares'.format(self.config['chain'])
-        chain_slice = 'chain_{}_slice'.format(self.config['chain'])
-        user_shares = '{}:{}'.format(address, shares)
         self.redis.hincrbyfloat(block_key, chain_key, shares)
-        self.redis.rpush(chain_slice, user_shares)
+        if not merged:
+            chain_slice = 'chain_{}_slice'.format(self.config['chain'])
+            user_shares = '{}:{}'.format(address, shares)
+            self.redis.rpush(chain_slice, user_shares)
 
     def log_share(self, client, diff, typ, params, job=None, header_hash=None, header=None,
                   **kwargs):


### PR DESCRIPTION
well, i'm not very clear about why push user_shares to chain_slice when log merged coin share, it will inflate chain_slice when there are many merged coins
