### PR TITLE
Config improvements, eliminate errors when 0 blocks mined

### DIFF
--- a/powerpool/jobmanagers/monitor_network.py
+++ b/powerpool/jobmanagers/monitor_network.py
@@ -359,8 +359,7 @@ class MonitorNetwork(Jobmanager, NodeMonitorMixin):
         coinbase.inputs.append(
             Input.coinbase(self._last_gbt['height'],
                            addtl_push=[mm_data] if mm_data else [],
-                           extra_script_sig=b'\0' * extranonce_length,
-                           desc_string=self.config['coinbase_string']))
+                           extra_script_sig=b'\0' * extranonce_length))
 
         coinbase_value = self._last_gbt['coinbasevalue']
 

--- a/powerpool/jobmanagers/switching_jobmanager.py
+++ b/powerpool/jobmanagers/switching_jobmanager.py
@@ -11,15 +11,9 @@ from binascii import hexlify
 
 
 class MonitorNetworkMulti(Jobmanager):
-    defaults = config = dict(jobmanagers=None,
-                             profit_poll_int=1,
-                             redis={},
-                             margin_switch=1.2,
-                             exchange_manager={})
-
     def __init__(self, config):
         self._configure(config)
-
+        super(Jobmanager, self).__init__()
         # Since some MonitorNetwork objs are polling and some aren't....
         self.gl_methods = ['update_profit']
 

--- a/powerpool/jobmanagers/switching_jobmanager.py
+++ b/powerpool/jobmanagers/switching_jobmanager.py
@@ -194,6 +194,10 @@ class MonitorNetworkMulti(Jobmanager):
         return True
 
     def new_job_notif(self, event):
+        if not hasattr('job', event):
+            self.logger.info("No blocks mined yet, skipping switch logic")
+            return 
+        
         currency = event.job.currency
         flush = event.job.type == 0
         if currency == self.current_network:

--- a/powerpool/reporters/redis_reporter.py
+++ b/powerpool/reporters/redis_reporter.py
@@ -43,6 +43,7 @@ class RedisReporter(QueueStatReporter):
     one_sec_stats = ['queued']
     gl_methods = ['_queue_proc', '_report_one_min']
     defaults = QueueStatReporter.defaults.copy()
+    # monkey patch for docker compose
     defaults.update(dict(redis={}, chain=1))
 
     def __init__(self, config):


### PR DESCRIPTION
- remove `AttributeError: 'Event' object has no attribute 'job'` error which appears when there are currently no blocked mined.
-  allow `MonitorNetworkMulti` to take properties by removing hard-coded values (in case we would like to update the `redis` host, when running on docker or remote host, for instance)  