### PR TITLE
Bug/pos and pow currencies

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -319,6 +319,12 @@ redis_scrypt:
     # multiplier - otherwise update at next job flush
     #margin_switch: 1.25
 
+    # redis host, to override default, if running on docker/docker-compose
+    # or a remote host
+    #redis:
+    #    host: 127.0.0.1
+    #    port: 6379
+
     # A list of jobmanagers to switch between
     #jobmanagers: REQUIRED. Expects []
 

--- a/powerpool/jobmanagers/monitor_network.py
+++ b/powerpool/jobmanagers/monitor_network.py
@@ -359,8 +359,7 @@ class MonitorNetwork(Jobmanager, NodeMonitorMixin):
         coinbase.inputs.append(
             Input.coinbase(self._last_gbt['height'],
                            addtl_push=[mm_data] if mm_data else [],
-                           extra_script_sig=b'\0' * extranonce_length,
-                           desc_string=self.config['coinbase_string']))
+                           extra_script_sig=b'\0' * extranonce_length))
 
         coinbase_value = self._last_gbt['coinbasevalue']
 

--- a/powerpool/jobmanagers/monitor_network.py
+++ b/powerpool/jobmanagers/monitor_network.py
@@ -356,11 +356,25 @@ class MonitorNetwork(Jobmanager, NodeMonitorMixin):
         # extranonces so script length is accurate
         extranonce_length = (self.manager.config['extranonce_size'] +
                              self.manager.config['extranonce_serv_size'])
+        coinbase_kwargs = {
+            'addtl_push': [mm_data] if mm_data else [],
+            'extra_script_sig': b'\0' * extranonce_length,
+            'desc_string': self.config['coinbase_string']
+        }
+        try:
+            coinbase = Input.coinbase(self._last_gbt['height'],
+                                      **coinbase_kwargs)
+        except TypeError as e:
+            self.logger.warn('tried to mine a POW '
+                             'block with POS interface'.format(e))
+            coinbase_kwargs.pop('desc_string')
+            coinbase = Input.coinbase(self._last_gbt['height'],
+                                      **coinbase_kwargs)
+
         coinbase.inputs.append(
-            Input.coinbase(self._last_gbt['height'],
-                           addtl_push=[mm_data] if mm_data else [],
-                           extra_script_sig=b'\0' * extranonce_length,
-                           desc_string=self.config['coinbase_string']))
+            coinbase
+        )
+
 
         coinbase_value = self._last_gbt['coinbasevalue']
 

--- a/powerpool/jobmanagers/monitor_network.py
+++ b/powerpool/jobmanagers/monitor_network.py
@@ -359,7 +359,8 @@ class MonitorNetwork(Jobmanager, NodeMonitorMixin):
         coinbase.inputs.append(
             Input.coinbase(self._last_gbt['height'],
                            addtl_push=[mm_data] if mm_data else [],
-                           extra_script_sig=b'\0' * extranonce_length))
+                           extra_script_sig=b'\0' * extranonce_length,
+                           desc_string=self.config['coinbase_string']))
 
         coinbase_value = self._last_gbt['coinbasevalue']
 

--- a/powerpool/jobmanagers/switching_jobmanager.py
+++ b/powerpool/jobmanagers/switching_jobmanager.py
@@ -11,15 +11,9 @@ from binascii import hexlify
 
 
 class MonitorNetworkMulti(Jobmanager):
-    defaults = config = dict(jobmanagers=None,
-                             profit_poll_int=1,
-                             redis={},
-                             margin_switch=1.2,
-                             exchange_manager={})
-
     def __init__(self, config):
         self._configure(config)
-
+        super(Jobmanager, self).__init__()
         # Since some MonitorNetwork objs are polling and some aren't....
         self.gl_methods = ['update_profit']
 

--- a/powerpool/jobmanagers/switching_jobmanager.py
+++ b/powerpool/jobmanagers/switching_jobmanager.py
@@ -194,6 +194,10 @@ class MonitorNetworkMulti(Jobmanager):
         return True
 
     def new_job_notif(self, event):
+        if not hasattr('job', event):
+            self.logger.info("No blocks mined yet, skipping switch logic")
+            return 
+        
         currency = event.job.currency
         flush = event.job.type == 0
         if currency == self.current_network:

--- a/powerpool/reporters/redis_reporter.py
+++ b/powerpool/reporters/redis_reporter.py
@@ -44,7 +44,7 @@ class RedisReporter(QueueStatReporter):
     gl_methods = ['_queue_proc', '_report_one_min']
     defaults = QueueStatReporter.defaults.copy()
     # monkey patch for docker compose
-    defaults.update(dict(redis={'host': '172.13.0.3'}, chain=1))
+    defaults.update(dict(redis={}, chain=1))
 
     def __init__(self, config):
         self._configure(config)

--- a/powerpool/reporters/redis_reporter.py
+++ b/powerpool/reporters/redis_reporter.py
@@ -43,7 +43,8 @@ class RedisReporter(QueueStatReporter):
     one_sec_stats = ['queued']
     gl_methods = ['_queue_proc', '_report_one_min']
     defaults = QueueStatReporter.defaults.copy()
-    defaults.update(dict(redis={}, chain=1))
+    # monkey patch for docker compose
+    defaults.update(dict(redis={'host': '172.13.0.3'}, chain=1))
 
     def __init__(self, config):
         self._configure(config)


### PR DESCRIPTION
- support POW/POS coins (both)
- Allow `MonitorNetworkMulti ` job manager to receive config params from the YAML config (extra useful if you run redis on a remote hoste or docker/docker-compose, does not restrict you to local machine)
- fail silently (with logging) if the current block is unavailable for some reason
- more info
https://groups.google.com/forum/#!topic/simplecrypto-dev/eKnBSUsU9Os

Full error:
```
[ 26 January 2017 14:14 ] Yuri: power-mining_1  | CoinRPCException: Invalid mode
power-mining_1  | ‎‎2017-01-26 10:28:51,509 [MonitorNetwork_MTLMC] [ERROR] {u'message': u'Invalid mode', u'code': -8}
[ 26 January 2017 14:15 ] Yuri: power-mining_1  | CoinRPCException: Invalid mode
power-mining_1  | ‎2017-01-26 10:21:18,061 [MonitorNetwork_MTLMC] [INFO] Retry 4 for connection 172.13.0.7:10435
power-mining_1  | ‎2017-01-26 10:21:18,064 [MonitorNetwork_MTLMC] [INFO] Block failed to submit to the server 172.13.0.7:10435 with submitblock! Unable to sign block, wallet locked?
power-mining_1  | ‎2017-01-26 10:21:18,064 [MonitorNetwork_MTLMC] [ERROR] {u'message': u'Unable to sign block, wallet locked?', u'code': -100}
power-mining_1  | Traceback (most recent call last):
power-mining_1  |   File "/home/powerpool/powerpool/jobmanagers/monitor_network.py", line 178, in submit_block
power-mining_1  |     res = conn.submitblock(block)
power-mining_1  |   File "/usr/local/lib/python2.7/dist-packages/cryptokit/rpc.py", line 194, in __call__
power-mining_1  |     return self._get_response(response)
power-mining_1  |   File "/usr/local/lib/python2.7/dist-packages/cryptokit/rpc.py", line 222, in _get_response
power-mining_1  |     raise CoinRPCException(response['error'])
power-mining_1  | CoinRPCException: Unable to sign block, wallet locked?
power-mining_1  | ‎2017-01-26 10:21:18,065 [MonitorNetwork_MTLMC] [ERROR] Block failed to submit to the server 172.13.0.7:10435!
power-mining_1  | Traceback (most recent call last):
power-mining_1  |   File "/home/powerpool/powerpool/jobmanagers/monitor_network.py", line 185, in submit_block
power-mining_1  |     res = conn.getblocktemplate({'mode': 'submit', 'data': block})
power-mining_1  |   File "/usr/local/lib/python2.7/dist-packages/cryptokit/rpc.py", line 194, in __call__
power-mining_1  |     return self._get_response(response)
power-mining_1  |   File "/usr/local/lib/python2.7/dist-packages/cryptokit/rpc.py", line 222, in _get_response
power-mining_1  |     raise CoinRPCException(response['error'])
power-mining_1  | CoinRPCException: Invalid mode
power-mining_1  | ‎2017-01-26 10:21:18,066 [MonitorNetwork_MTLMC] [ERROR] {u'message': u'Invalid mode', u'code': -8}
power-mining_1  | ‎2017-01-26 10:21:18,066 [MonitorNetwork_MTLMC] [ERROR] Block failed to submit to the server 172.13.0.7:10435, server returned failed!
power-mining_1  | Traceback (most recent call last):
power-mining_1  |   File "/home/powerpool/powerpool/jobmanagers/monitor_network.py", line 185, in submit_block
power-mining_1  |     res = conn.getblocktemplate({'mode': 'submit', 'data': block})
power-mining_1  |   File "/usr/local/lib/python2.7/dist-packages/cryptokit/rpc.py", line 194, in __call__
power-mining_1  |     return self._get_response(response)
power-mining_1  |   File "/usr/local/lib/python2.7/dist-packages/cryptokit/rpc.py", line 222, in _get_response
power-mining_1  |     raise CoinRPCException(response['error'])
power-mining_1  | CoinRPCException: Invalid mode
power-mining_1  | ‎2017-01-26 10:21:19,066 [MonitorNetwork_MTLMC] [INFO] Retry 5 for connection 172.13.0.7:10435
power-mining_1  | ‎2017-01-26 10:21:19,067 [MonitorNetwork_MTLMC] [INFO] Recording block submission outcome False after 5.‎04199004173
power-mining_1  | ‎2017-01-26 10:21:19,068 [MonitorNetwork_MTLMC] [INFO] MTLMC BLOCK ca0fc7755b730b88f031dc7826001dda559391dd92d29249c365be1d2670d7f0:‎1
```
